### PR TITLE
Support for Scala .ext and generic support for any other undefined language

### DIFF
--- a/lib/popup.js
+++ b/lib/popup.js
@@ -247,6 +247,8 @@ function getExtension(lang) {
       return '.rb'
     case 'Go':
       return '.go';
+    case 'Scala':
+      return '.scala'
     case 'Swift':
       return '.swift'
     case 'C++':

--- a/lib/popup.js
+++ b/lib/popup.js
@@ -254,6 +254,6 @@ function getExtension(lang) {
     case 'C++':
       return '.cpp'
     default:
-      return ".${lang.toLowerCase()}";
+      return '.${lang.toLowerCase()}';
   }
 }

--- a/lib/popup.js
+++ b/lib/popup.js
@@ -254,6 +254,6 @@ function getExtension(lang) {
     case 'C++':
       return '.cpp'
     default:
-      return lang;
+      return ".${lang.toLowerCase()}";
   }
 }


### PR DESCRIPTION
Add using .scala with Scala submissions. Add generic support for any other undefine language by converting and using `.$lang` to lowercase.